### PR TITLE
Add basic transactions listing API

### DIFF
--- a/backend/src/controllers/transaction.controller.ts
+++ b/backend/src/controllers/transaction.controller.ts
@@ -1,0 +1,34 @@
+import { Request, Response, NextFunction } from 'express';
+import { transactionService } from '../services';
+import { sendSuccessResponse } from '../utils/apiResponse';
+import { UnauthorizedError } from '../errors/AppError';
+
+export class TransactionController {
+  static async listTransactions(req: Request, res: Response, next: NextFunction) {
+    try {
+      const userId = req.user?.id;
+      if (!userId) {
+        throw new UnauthorizedError('User not authenticated');
+      }
+
+      const { page, limit, startDate, endDate, category, search } = req.query;
+
+      const result = await transactionService.getTransactions({
+        userId,
+        page: page ? parseInt(page as string, 10) : 1,
+        limit: limit ? parseInt(limit as string, 10) : 50,
+        startDate: startDate ? new Date(startDate as string) : undefined,
+        endDate: endDate ? new Date(endDate as string) : undefined,
+        category: category as string | undefined,
+        search: search as string | undefined,
+      });
+
+      sendSuccessResponse(res, result);
+      return;
+    } catch (error) {
+      next(error);
+    }
+  }
+}
+
+export default TransactionController;

--- a/backend/src/routes/transaction.routes.ts
+++ b/backend/src/routes/transaction.routes.ts
@@ -1,0 +1,15 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import { TransactionController } from '../controllers/transaction.controller';
+import { authMiddleware } from '../middleware/auth.middleware';
+
+const router = Router();
+
+const authHandler = (req: Request, res: Response, next: NextFunction) => {
+  return (authMiddleware as any)(req, res, next);
+};
+
+router.use(authHandler);
+
+router.get('/', TransactionController.listTransactions);
+
+export default router;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -19,6 +19,7 @@ import { logger } from './utils/logger';
 
 // Import routes
 import plaidRoutes from './routes/plaid.routes';
+import transactionRoutes from './routes/transaction.routes';
 // Import auth middleware if needed
 // import { authMiddleware } from './middleware/auth.middleware';
 
@@ -49,6 +50,7 @@ app.use(express.urlencoded({ extended: true }));
 
 // API Routes
 app.use('/api/plaid', plaidRoutes);
+app.use('/api/transactions', transactionRoutes);
 
 // Webhook Routes (no JSON body parsing for webhooks)
 const webhookRouter = Router();


### PR DESCRIPTION
## Summary
- implement TransactionController with a list endpoint
- expose `/api/transactions` route secured with auth middleware
- register new route in server

## Testing
- `npx jest` *(fails: connect EHOSTUNREACH 172.25.0.3:8080)*